### PR TITLE
[Config] Update Monolog settings to include Adyen-specific channels and handlers

### DIFF
--- a/tests/TestApplication/config/config.yaml
+++ b/tests/TestApplication/config/config.yaml
@@ -42,16 +42,98 @@ sylius_resource:
                 repository: Tests\Sylius\AdyenPlugin\Repository\RefundPaymentRepository
 
 monolog:
-    channels: [adyen]
+    channels: ["app", "doctrine", "event", "php", "adyen"]
+
     handlers:
+        adyen_file:
+            type: rotating_file
+            path: "%kernel.logs_dir%/adyen-%kernel.environment%.log"
+            max_files: 30
+            level: info
+            channels: ["adyen"]
+            formatter: monolog.formatter.line
+
+        adyen_doctrine:
+            type: service
+            id: sylius_adyen.logging.monolog.doctrine_handler
+            channels: ["adyen"]
+
+        console:
+            type: console
+            process_psr_3_messages: false
+            channels: ["!event", "!doctrine"]
+
         main:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
-        firephp:
-            type: firephp
-            level: info
+            channels: ["!event", "!doctrine", "!php", "!adyen"]
+            formatter: monolog.formatter.line
+
         doctrine:
-            type: service
-            channels: [adyen]
-            id: sylius_adyen.logging.monolog.doctrine_handler
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%_doctrine.log"
+            level: warning
+            channels: ["doctrine"]
+
+        php:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%_php.log"
+            level: info
+            channels: ["php"]
+
+        dedup:
+            type: deduplication
+            handler: main
+
+when@dev:
+    monolog:
+        handlers:
+            main:
+                type: stream
+                path: "%kernel.logs_dir%/dev_app.log"
+                level: debug
+                channels: ["!event", "!doctrine", "!php", "!adyen"]
+                formatter: monolog.formatter.line
+
+            doctrine:
+                type: stream
+                path: "%kernel.logs_dir%/dev_doctrine.log"
+                level: warning
+                channels: ["doctrine"]
+
+            php:
+                type: stream
+                path: "%kernel.logs_dir%/dev_php.log"
+                level: info
+                channels: ["php"]
+
+            adyen_file:
+                type: rotating_file
+                path: "%kernel.logs_dir%/adyen-dev.log"
+                max_files: 14
+                level: debug
+                channels: ["adyen"]
+                formatter: monolog.formatter.line
+
+            firephp:
+                type: firephp
+                level: info
+                channels: ["!doctrine", "!event", "!php"]
+
+when@prod:
+    monolog:
+        handlers:
+            fingers:
+                type: fingers_crossed
+                action_level: warning
+                handler: dedup
+                buffer_size: 200
+
+            adyen_file:
+                type: rotating_file
+                path: "%kernel.logs_dir%/adyen-%kernel.environment%.log"
+                max_files: 30
+                level: info
+                channels: ["adyen"]
+                formatter: monolog.formatter.line


### PR DESCRIPTION
It introduced a simpler way to browse logs:

<img width="329" height="220" alt="image" src="https://github.com/user-attachments/assets/f9e9192d-e13f-4664-8206-3161d34c21c5" />
