### PR TITLE
[Maintenance] Cascade payment removal to adyen references

### DIFF
--- a/config/doctrine/AdyenReference.orm.xml
+++ b/config/doctrine/AdyenReference.orm.xml
@@ -10,6 +10,7 @@
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO"/>
         </id>
+
         <field name="pspReference" type="string" column="psp_reference" length="64" unique="true" />
 
         <field name="createdAt" column="created_at" type="datetime">
@@ -19,7 +20,9 @@
             <gedmo:timestampable on="update"/>
         </field>
 
-        <many-to-one field="payment" target-entity="Sylius\Component\Payment\Model\PaymentInterface" />
+        <many-to-one field="payment" target-entity="Sylius\Component\Payment\Model\PaymentInterface">
+            <join-column name="payment_id" on-delete="CASCADE"/>
+        </many-to-one>
         <one-to-one field="refundPayment" target-entity="Sylius\RefundPlugin\Entity\RefundPaymentInterface">
             <join-column name="refund_payment_id"/>
         </one-to-one>

--- a/src/Controller/Shop/ProcessNotificationsAction.php
+++ b/src/Controller/Shop/ProcessNotificationsAction.php
@@ -55,7 +55,7 @@ class ProcessNotificationsAction
             } catch (NoCommandResolvedException $ex) {
                 $this->logger->error(sprintf(
                     'Tried to dispatch an unknown command. Notification body: %s',
-                    json_encode($notificationItem, JSON_PARTIAL_OUTPUT_ON_ERROR),
+                    json_encode($notificationItem, \JSON_PARTIAL_OUTPUT_ON_ERROR),
                 ));
             }
         }

--- a/src/Migrations/Version20250820131406.php
+++ b/src/Migrations/Version20250820131406.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius Adyen Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\AdyenPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250820131406 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_adyen_reference DROP FOREIGN KEY FK_7FD033A84C3A3BB');
+        $this->addSql('ALTER TABLE sylius_adyen_reference ADD CONSTRAINT FK_7FD033A84C3A3BB FOREIGN KEY (payment_id) REFERENCES sylius_payment (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_adyen_reference DROP FOREIGN KEY FK_7FD033A84C3A3BB');
+        $this->addSql('ALTER TABLE sylius_adyen_reference ADD CONSTRAINT FK_7FD033A84C3A3BB FOREIGN KEY (payment_id) REFERENCES sylius_payment (id) ON UPDATE NO ACTION ON DELETE NO ACTION');
+    }
+}


### PR DESCRIPTION
Steps to reproduce:
1. Go through checkout as normally
2. Fail or cancel the payment
3. Abandon the cart (change the `updateAt` date of the cart to a month ago etc.)
4. Run the `sylius:remove-expired-carts` command
5. Result:
	Before - Crash
	Now - The cart gets removed