### PR TITLE
Refactor Adyen response processors to remove payment command dispatching

### DIFF
--- a/config/services/response_processors.xml
+++ b/config/services/response_processors.xml
@@ -30,9 +30,6 @@
             class="Sylius\AdyenPlugin\Processor\PaymentResponseProcessor\FailedResponseProcessor"
             parent="sylius_adyen.processor.payment_response_processor.abstract"
         >
-            <argument type="service" id="sylius.command_bus"/>
-            <argument type="service" id="sylius_adyen.bus.payment_command_factory"/>
-
             <tag name="sylius_adyen.processor.payment_response"/>
         </service>
 
@@ -41,9 +38,6 @@
             class="Sylius\AdyenPlugin\Processor\PaymentResponseProcessor\SuccessfulResponseProcessor"
             parent="sylius_adyen.processor.payment_response_processor.abstract"
         >
-            <argument type="service" id="sylius.command_bus"/>
-            <argument type="service" id="sylius_adyen.bus.payment_command_factory"/>
-
             <tag name="sylius_adyen.processor.payment_response"/>
         </service>
 
@@ -52,9 +46,6 @@
             class="Sylius\AdyenPlugin\Processor\PaymentResponseProcessor\PaymentProcessingResponseProcessor"
             parent="sylius_adyen.processor.payment_response_processor.abstract"
         >
-            <argument type="service" id="sylius.command_bus"/>
-            <argument type="service" id="sylius_adyen.bus.payment_command_factory"/>
-
             <tag name="sylius_adyen.processor.payment_response"/>
         </service>
 

--- a/src/Processor/PaymentResponseProcessor.php
+++ b/src/Processor/PaymentResponseProcessor.php
@@ -22,37 +22,11 @@ final class PaymentResponseProcessor implements PaymentResponseProcessorInterfac
 {
     private const DEFAULT_REDIRECT_ROUTE = 'sylius_shop_order_thank_you';
 
-    /** @var iterable<ProcessorInterface> */
-    private $processors;
-
-    /** @var UrlGeneratorInterface */
-    private $urlGenerator;
-
-    /**
-     * @param iterable<ProcessorInterface> $processors
-     */
+    /** @param iterable<ProcessorInterface> $processors */
     public function __construct(
-        iterable $processors,
-        UrlGeneratorInterface $urlGenerator,
+        private readonly iterable $processors,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
-        $this->processors = $processors;
-        $this->urlGenerator = $urlGenerator;
-    }
-
-    private function processForPaymentSpecified(
-        string $code,
-        Request $request,
-        PaymentInterface $payment,
-    ): ?string {
-        foreach ($this->processors as $processor) {
-            if (!$processor->accepts($request, $payment)) {
-                continue;
-            }
-
-            return $processor->process($code, $request, $payment);
-        }
-
-        return null;
     }
 
     public function process(
@@ -72,5 +46,21 @@ final class PaymentResponseProcessor implements PaymentResponseProcessorInterfac
         return $this->urlGenerator->generate(self::DEFAULT_REDIRECT_ROUTE, [
             '_locale' => $payment?->getOrder()?->getLocaleCode() ?? $request->getLocale(),
         ]);
+    }
+
+    private function processForPaymentSpecified(
+        string $code,
+        Request $request,
+        PaymentInterface $payment,
+    ): ?string {
+        foreach ($this->processors as $processor) {
+            if (!$processor->accepts($request, $payment)) {
+                continue;
+            }
+
+            return $processor->process($code, $request, $payment);
+        }
+
+        return null;
     }
 }

--- a/src/Processor/PaymentResponseProcessor/AbstractProcessor.php
+++ b/src/Processor/PaymentResponseProcessor/AbstractProcessor.php
@@ -21,8 +21,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class AbstractProcessor implements ProcessorInterface
 {
-    public const PAYMENT_STATUS_RECEIVED_CODE = 'payment_status_received';
-
     public const FLASH_INFO = 'info';
 
     public const FLASH_ERROR = 'error';

--- a/src/Processor/PaymentResponseProcessor/FailedResponseProcessor.php
+++ b/src/Processor/PaymentResponseProcessor/FailedResponseProcessor.php
@@ -13,12 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\AdyenPlugin\Processor\PaymentResponseProcessor;
 
-use Sylius\AdyenPlugin\Bus\PaymentCommandFactoryInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 use Webmozart\Assert\Assert;
 
 final class FailedResponseProcessor extends AbstractProcessor
@@ -31,15 +27,6 @@ final class FailedResponseProcessor extends AbstractProcessor
 
     public const LABEL_PAYMENT_FAILED = 'sylius_adyen.ui.payment_failed';
 
-    public function __construct(
-        UrlGeneratorInterface $urlGenerator,
-        TranslatorInterface $translator,
-        private readonly MessageBusInterface $messageBus,
-        private readonly PaymentCommandFactoryInterface $paymentCommandFactory,
-    ) {
-        parent::__construct($urlGenerator, $translator);
-    }
-
     public function accepts(Request $request, ?PaymentInterface $payment): bool
     {
         return $this->isResultCodeSupportedForPayment($payment, self::PAYMENT_REFUSED_CODES);
@@ -51,9 +38,6 @@ final class FailedResponseProcessor extends AbstractProcessor
         PaymentInterface $payment,
     ): string {
         $this->addFlash($request, self::FLASH_ERROR, self::LABEL_PAYMENT_FAILED);
-
-        $paymentStatusReceivedCommand = $this->paymentCommandFactory->createForEvent(self::PAYMENT_STATUS_RECEIVED_CODE, $payment);
-        $this->messageBus->dispatch($paymentStatusReceivedCommand);
 
         return $this->getRedirectUrl($payment, $request);
     }

--- a/src/Processor/PaymentResponseProcessor/PaymentProcessingResponseProcessor.php
+++ b/src/Processor/PaymentResponseProcessor/PaymentProcessingResponseProcessor.php
@@ -31,8 +31,6 @@ final class PaymentProcessingResponseProcessor extends AbstractProcessor
     public function __construct(
         UrlGeneratorInterface $urlGenerator,
         TranslatorInterface $translator,
-        private readonly MessageBusInterface $messageBus,
-        private readonly PaymentCommandFactoryInterface $paymentCommandFactory,
     ) {
         parent::__construct($urlGenerator, $translator);
     }
@@ -47,9 +45,6 @@ final class PaymentProcessingResponseProcessor extends AbstractProcessor
         Request $request,
         PaymentInterface $payment,
     ): string {
-        $paymentStatusReceivedCommand = $this->paymentCommandFactory->createForEvent(self::PAYMENT_STATUS_RECEIVED_CODE, $payment);
-        $this->messageBus->dispatch($paymentStatusReceivedCommand);
-
         $this->addFlash($request, self::FLASH_INFO, self::LABEL_PROCESSING);
 
         return $this->generateUrl(self::REDIRECT_TARGET_ROUTE, $request, $payment);

--- a/src/Processor/PaymentResponseProcessor/SuccessfulResponseProcessor.php
+++ b/src/Processor/PaymentResponseProcessor/SuccessfulResponseProcessor.php
@@ -34,15 +34,6 @@ class SuccessfulResponseProcessor extends AbstractProcessor
 
     public const LABEL_PAYMENT_COMPLETED = 'sylius.payment.completed';
 
-    public function __construct(
-        UrlGeneratorInterface $urlGenerator,
-        TranslatorInterface $translator,
-        private readonly MessageBusInterface $messageBus,
-        private readonly PaymentCommandFactoryInterface $paymentCommandFactory,
-    ) {
-        parent::__construct($urlGenerator, $translator);
-    }
-
     public function accepts(Request $request, ?PaymentInterface $payment): bool
     {
         return $this->isResultCodeSupportedForPayment($payment, self::PAYMENT_PROCEED_CODES);
@@ -54,9 +45,6 @@ class SuccessfulResponseProcessor extends AbstractProcessor
         PaymentInterface $payment,
     ): string {
         $targetRoute = self::THANKS_ROUTE_NAME;
-
-        $paymentStatusReceivedCommand = $this->paymentCommandFactory->createForEvent(self::PAYMENT_STATUS_RECEIVED_CODE, $payment);
-        $this->messageBus->dispatch($paymentStatusReceivedCommand);
 
         if ($this->shouldTheAlternativeThanksPageBeShown($request)) {
             $this->addFlash($request, self::FLASH_INFO, self::LABEL_PAYMENT_COMPLETED);

--- a/tests/Functional/ResponseProcessing/PaymentResponseProcessor/FailedResponseProcessorTest.php
+++ b/tests/Functional/ResponseProcessing/PaymentResponseProcessor/FailedResponseProcessorTest.php
@@ -13,37 +13,20 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\AdyenPlugin\Functional\ResponseProcessing\PaymentResponseProcessor;
 
-use Sylius\AdyenPlugin\Bus\Command\PaymentLifecycleCommand;
-use Sylius\AdyenPlugin\Bus\PaymentCommandFactoryInterface;
 use Sylius\AdyenPlugin\Processor\PaymentResponseProcessor\FailedResponseProcessor;
-use Sylius\AdyenPlugin\Processor\PaymentResponseProcessor\SuccessfulResponseProcessor;
-use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Tests\Sylius\AdyenPlugin\Unit\Mock\RequestMother;
 
 class FailedResponseProcessorTest extends AbstractProcessor
 {
     private const TOKEN_VALUE = 'Szczebrzeszyn';
 
-    /** @var MessageBusInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $messageBus;
-
-    /** @var PaymentCommandFactoryInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $paymentCommandFactory;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->messageBus = $this->createMock(MessageBusInterface::class);
-        $this->paymentCommandFactory = $this->createMock(PaymentCommandFactoryInterface::class);
-
         $this->processor = new FailedResponseProcessor(
             self::getRouter($this->getContainer()),
-            $this->getContainer()->get('translator'),
-            $this->messageBus,
-            $this->paymentCommandFactory,
+            self::getContainer()->get('translator'),
         );
     }
 
@@ -52,25 +35,10 @@ class FailedResponseProcessorTest extends AbstractProcessor
         $payment = $this->getPayment('authorized', self::TOKEN_VALUE);
 
         $request = RequestMother::createWithSession();
-
-        $paymentStatusReceivedCommand = $this->createMock(PaymentLifecycleCommand::class);
-        $this->paymentCommandFactory
-            ->expects($this->once())
-            ->method('createForEvent')
-            ->with(SuccessfulResponseProcessor::PAYMENT_STATUS_RECEIVED_CODE, $payment)
-            ->willReturn($paymentStatusReceivedCommand);
-
-        $this->messageBus
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($paymentStatusReceivedCommand)
-            ->willReturn(Envelope::wrap(new \stdClass(), [new HandledStamp(true, static::class)]))
-        ;
-
         $result = $this->processor->process('code', $request, $payment);
 
-        $this->assertStringEndsWith(self::TOKEN_VALUE, $result);
-        $this->assertNotEmpty($request->getSession()->getFlashBag()->get('error'));
+        self::assertStringEndsWith(self::TOKEN_VALUE, $result);
+        self::assertNotEmpty($request->getSession()->getFlashBag()->get('error'));
     }
 
     public static function provideForTestAccepts(): array

--- a/tests/Functional/ResponseProcessing/PaymentResponseProcessor/SuccessfulResponseProcessorTest.php
+++ b/tests/Functional/ResponseProcessing/PaymentResponseProcessor/SuccessfulResponseProcessorTest.php
@@ -14,36 +14,20 @@ declare(strict_types=1);
 namespace Tests\Sylius\AdyenPlugin\Functional\ResponseProcessing\PaymentResponseProcessor;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use Sylius\AdyenPlugin\Bus\Command\PaymentLifecycleCommand;
-use Sylius\AdyenPlugin\Bus\PaymentCommandFactoryInterface;
 use Sylius\AdyenPlugin\Processor\PaymentResponseProcessor\SuccessfulResponseProcessor;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Tests\Sylius\AdyenPlugin\Unit\Mock\RequestMother;
 
 class SuccessfulResponseProcessorTest extends AbstractProcessor
 {
-    /** @var MessageBusInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $messageBus;
-
-    /** @var PaymentCommandFactoryInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $paymentCommandFactory;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->messageBus = $this->createMock(MessageBusInterface::class);
-        $this->paymentCommandFactory = $this->createMock(PaymentCommandFactoryInterface::class);
-
         $this->processor = new SuccessfulResponseProcessor(
-            self::getRouter($this->getContainer()),
-            $this->getContainer()->get('translator'),
-            $this->messageBus,
-            $this->paymentCommandFactory,
+            self::getRouter(self::getContainer()),
+            self::getContainer()->get('translator'),
         );
     }
 
@@ -77,29 +61,14 @@ class SuccessfulResponseProcessorTest extends AbstractProcessor
         bool $expectFlash = false,
     ) {
         $payment = $this->createMock(PaymentInterface::class);
-
-        $paymentStatusReceivedCommand = $this->createMock(PaymentLifecycleCommand::class);
-        $this->paymentCommandFactory
-            ->expects($this->once())
-            ->method('createForEvent')
-            ->with(SuccessfulResponseProcessor::PAYMENT_STATUS_RECEIVED_CODE, $payment)
-            ->willReturn($paymentStatusReceivedCommand);
-
-        $this->messageBus
-            ->expects($this->once())
-            ->method('dispatch')
-            ->with($paymentStatusReceivedCommand)
-            ->willReturn(Envelope::wrap(new \stdClass(), [new HandledStamp(true, static::class)]))
-        ;
-
         $result = $this->processor->process('Szczebrzeszyn', $request, $payment);
 
-        $this->assertStringEndsWith($expectedUrlEnding, $result);
+        self::assertStringEndsWith($expectedUrlEnding, $result);
 
         if (!$expectFlash) {
             return;
         }
 
-        $this->assertNotEmpty($request->getSession()->getFlashbag()->get('info'));
+        self::assertNotEmpty($request->getSession()->getFlashbag()->get('info'));
     }
 }


### PR DESCRIPTION
<img width="332" height="47" alt="image" src="https://github.com/user-attachments/assets/a569f805-812f-4000-8872-d629039cbdda" />
<img width="398" height="536" alt="image" src="https://github.com/user-attachments/assets/d86aece6-8774-4227-a074-7088272beb22" />


It seems these command dispatches weren't necessary, so I simplified the process. I manually tested the checkout flow, and it works as expected for both successful and failed payments.
