### PR TITLE
[ExpressCheckout] Render buttons only if payment method is available

### DIFF
--- a/assets/shop/js/express-checkout/cart/main.js
+++ b/assets/shop/js/express-checkout/cart/main.js
@@ -41,17 +41,19 @@ const initExpressCheckout = async ($container) => {
         }
     }
 
-    try {
-        const googlePayHandler = new GooglePayHandler(configuration);
-        const googlePay = new GooglePay(checkout, googlePayHandler.getConfig());
+    if (isPaymentMethodAvailable(configuration.paymentMethods, 'googlepay')) {
+        try {
+            const googlePayHandler = new GooglePayHandler(configuration);
+            const googlePay = new GooglePay(checkout, googlePayHandler.getConfig());
 
-        googlePay
-            .isAvailable()
-            .then(() => {
-                googlePay.mount(SELECTORS.GOOGLEPAY_MOUNT);
-            });
-    } catch (e) {
-        console.error('Google Pay is not available');
+            googlePay
+                .isAvailable()
+                .then(() => {
+                    googlePay.mount(SELECTORS.GOOGLEPAY_MOUNT);
+                });
+        } catch (e) {
+            console.error('Google Pay is not available');
+        }
     }
 
     if (isPaymentMethodAvailable(configuration.paymentMethods, 'paypal')) {

--- a/assets/shop/js/express-checkout/cart/main.js
+++ b/assets/shop/js/express-checkout/cart/main.js
@@ -4,6 +4,12 @@ import { ApplePayHandler } from './applepay.js';
 import { GooglePayHandler } from './googlepay.js';
 import { PayPalHandler } from './paypal.js';
 
+const isPaymentMethodAvailable = (paymentMethodData, type) => {
+    if (!paymentMethodData || !paymentMethodData.paymentMethods) return false;
+
+    return paymentMethodData.paymentMethods.some(method => method.type === type);
+};
+
 const initExpressCheckout = async ($container) => {
     const configUrl = $container.getAttribute('data-config-url');
     if (!configUrl) return;
@@ -20,17 +26,19 @@ const initExpressCheckout = async ($container) => {
         countryCode: configuration.allowedCountryCodes[0],
     });
 
-    try {
-        const applePayHandler = new ApplePayHandler(configuration);
-        const applePay = new ApplePay(checkout, applePayHandler.getConfig());
+    if (isPaymentMethodAvailable(configuration.paymentMethods, 'applepay')) {
+        try {
+            const applePayHandler = new ApplePayHandler(configuration);
+            const applePay = new ApplePay(checkout, applePayHandler.getConfig());
 
-        applePay
-            .isAvailable()
-            .then(() => {
-                applePay.mount(SELECTORS.APPLEPAY_MOUNT);
-            });
-    } catch (e) {
-        console.error('Apple Pay is not available');
+            applePay
+                .isAvailable()
+                .then(() => {
+                    applePay.mount(SELECTORS.APPLEPAY_MOUNT);
+                });
+        } catch (e) {
+            console.error('Apple Pay is not available');
+        }
     }
 
     try {
@@ -46,17 +54,19 @@ const initExpressCheckout = async ($container) => {
         console.error('Google Pay is not available');
     }
 
-    try {
-        const paypalHandler = new PayPalHandler(configuration);
-        const payPal = new PayPal(checkout, paypalHandler.getConfig());
+    if (isPaymentMethodAvailable(configuration.paymentMethods, 'paypal')) {
+        try {
+            const paypalHandler = new PayPalHandler(configuration);
+            const payPal = new PayPal(checkout, paypalHandler.getConfig());
 
-        payPal
-            .isAvailable()
-            .then(() => {
-                payPal.mount(SELECTORS.PAYPAL_MOUNT);
-            });
-    } catch (e) {
-        console.error('PayPal is not available');
+            payPal
+                .isAvailable()
+                .then(() => {
+                    payPal.mount(SELECTORS.PAYPAL_MOUNT);
+                });
+        } catch (e) {
+            console.error('PayPal is not available');
+        }
     }
 };
 

--- a/assets/shop/js/express-checkout/product/main.js
+++ b/assets/shop/js/express-checkout/product/main.js
@@ -4,6 +4,12 @@ import { ApplePayHandler } from './applepay.js';
 import { GooglePayHandler } from './googlepay.js';
 import { PayPalHandler } from "./paypal.js";
 
+const isPaymentMethodAvailable = (paymentMethodData, type) => {
+    if (!paymentMethodData || !paymentMethodData.paymentMethods) return false;
+
+    return paymentMethodData.paymentMethods.some(method => method.type === type);
+};
+
 const initExpressCheckout = async ($container) => {
     const configUrl = $container.getAttribute('data-config-url');
     const productId = $container.getAttribute('data-product-id');
@@ -21,17 +27,19 @@ const initExpressCheckout = async ($container) => {
         countryCode: configuration.allowedCountryCodes[0],
     });
 
-    try {
-        const applePayHandler = new ApplePayHandler(configuration);
-        const applePay = new ApplePay(checkout, applePayHandler.getConfig(productId));
+    if (isPaymentMethodAvailable(configuration.paymentMethods, 'applepay')) {
+        try {
+            const applePayHandler = new ApplePayHandler(configuration);
+            const applePay = new ApplePay(checkout, applePayHandler.getConfig(productId));
 
-        applePay
-            .isAvailable()
-            .then(() => {
-                applePay.mount(SELECTORS.APPLEPAY_MOUNT);
-            });
-    } catch (e) {
-        console.error('Apple Pay is not available');
+            applePay
+                .isAvailable()
+                .then(() => {
+                    applePay.mount(SELECTORS.APPLEPAY_MOUNT);
+                });
+        } catch (e) {
+            console.error('Apple Pay is not available');
+        }
     }
 
     try {
@@ -47,17 +55,19 @@ const initExpressCheckout = async ($container) => {
         console.error('Google Pay is not available');
     }
 
-    try {
-        const paypalHandler = new PayPalHandler(configuration);
-        const payPal = new PayPal(checkout, paypalHandler.getConfig(productId));
+    if (isPaymentMethodAvailable(configuration.paymentMethods, 'paypal')) {
+        try {
+            const paypalHandler = new PayPalHandler(configuration);
+            const payPal = new PayPal(checkout, paypalHandler.getConfig(productId));
 
-        payPal
-            .isAvailable()
-            .then(() => {
-                payPal.mount(SELECTORS.PAYPAL_MOUNT);
-            });
-    } catch (e) {
-        console.error('PayPal is not available');
+            payPal
+                .isAvailable()
+                .then(() => {
+                    payPal.mount(SELECTORS.PAYPAL_MOUNT);
+                });
+        } catch (e) {
+            console.error('PayPal is not available');
+        }
     }
 };
 

--- a/assets/shop/js/express-checkout/product/main.js
+++ b/assets/shop/js/express-checkout/product/main.js
@@ -42,17 +42,19 @@ const initExpressCheckout = async ($container) => {
         }
     }
 
-    try {
-        const googlePayHandler = new GooglePayHandler(configuration);
-        const googlePay = new GooglePay(checkout, googlePayHandler.getConfig(productId));
+    if (isPaymentMethodAvailable(configuration.paymentMethods, 'googlepay')) {
+        try {
+            const googlePayHandler = new GooglePayHandler(configuration);
+            const googlePay = new GooglePay(checkout, googlePayHandler.getConfig(productId));
 
-        googlePay
-            .isAvailable()
-            .then(() => {
-                googlePay.mount(SELECTORS.GOOGLEPAY_MOUNT);
-            });
-    } catch (e) {
-        console.error('Google Pay is not available');
+            googlePay
+                .isAvailable()
+                .then(() => {
+                    googlePay.mount(SELECTORS.GOOGLEPAY_MOUNT);
+                });
+        } catch (e) {
+            console.error('Google Pay is not available');
+        }
     }
 
     if (isPaymentMethodAvailable(configuration.paymentMethods, 'paypal')) {


### PR DESCRIPTION
<strike>Added validation only for `Apple Pay` and `PayPal`, since `Google Pay` was already checking the provided payment methods based on the given configuration.</strike>