### PR TITLE
[Maintenance][Workflow] Fix invalid cancel listener id in compiler pass

### DIFF
--- a/src/DependencyInjection/Compiler/RemoveCancelPaymentListenerPass.php
+++ b/src/DependencyInjection/Compiler/RemoveCancelPaymentListenerPass.php
@@ -22,9 +22,9 @@ final class RemoveCancelPaymentListenerPass implements CompilerPassInterface
     {
         if (
             $container->hasDefinition('state_machine.sylius_order.definition') &&
-            $container->hasDefinition('Sylius\Bundle\CoreBundle\EventListener\Workflow\Order\CancelPaymentListener')
+            $container->hasDefinition('sylius.listener.workflow.order.cancel_payment')
         ) {
-            $container->removeDefinition('Sylius\Bundle\CoreBundle\EventListener\Workflow\Order\CancelPaymentListener');
+            $container->removeDefinition('sylius.listener.workflow.order.cancel_payment');
         }
     }
 }

--- a/tests/Functional/OrderProcessing/PaymentReversalTest.php
+++ b/tests/Functional/OrderProcessing/PaymentReversalTest.php
@@ -25,6 +25,7 @@ use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethod;
 use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Order\OrderTransitions;
 use Sylius\RefundPlugin\Entity\RefundPaymentInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -148,6 +149,34 @@ final class PaymentReversalTest extends AdyenTestCase
         $request = new Request();
         ($this->reverseOrderPaymentAction)((string) $this->testOrder->getId(), (string) $payment->getId(), $request);
 
+        self::assertEquals(PaymentGraph::STATE_PROCESSING_REVERSAL, $payment->getState());
+    }
+
+    public function testPaymentStateChangesToProcessingReversalOnCancelWithAutomaticCapture(): void
+    {
+        $this->setupOrderWithAdyenPayment();
+
+        $payment = $this->testOrder->getLastPayment();
+        $payment->setState(PaymentInterface::STATE_COMPLETED);
+        $this->testOrder->setState(OrderInterface::STATE_NEW);
+        $this->testOrder->setPaymentState(OrderPaymentStates::STATE_PAID);
+
+        $this->getEntityManager()->flush();
+
+        $initialDetails = $payment->getDetails();
+        self::assertArrayHasKey('pspReference', $initialDetails);
+        self::assertEquals('TEST_PSP_REF_123', $initialDetails['pspReference']);
+
+        $this->adyenClientStub->setReversalResponse([
+            'paymentPspReference' => 'TEST_PSP_REF_123',
+            'pspReference' => 'REVERSAL_PSP_REF_999',
+            'status' => ResponseStatus::RECEIVED,
+        ]);
+
+        $this->stateMachine->apply($this->testOrder, OrderTransitions::GRAPH, OrderTransitions::TRANSITION_CANCEL);
+
+        self::assertEquals(OrderInterface::STATE_CANCELLED, $this->testOrder->getState());
+        self::assertEquals(OrderPaymentStates::STATE_PAID, $this->testOrder->getPaymentState());
         self::assertEquals(PaymentGraph::STATE_PROCESSING_REVERSAL, $payment->getState());
     }
 

--- a/tests/Unit/DependencyInjection/Compiler/RemoveCancelPaymentListenerPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/RemoveCancelPaymentListenerPassTest.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\Definition;
 
 final class RemoveCancelPaymentListenerPassTest extends TestCase
 {
+    private const CANCEL_PAYMENT_LISTENER_SERVICE_ID = 'sylius.listener.workflow.order.cancel_payment';
+
     private RemoveCancelPaymentListenerPass $compilerPass;
 
     private ContainerBuilder $container;
@@ -33,11 +35,11 @@ final class RemoveCancelPaymentListenerPassTest extends TestCase
     public function testItDoesNothingWhenOrderWorkflowDefinitionDoesNotExist(): void
     {
         $listenerDefinition = new Definition();
-        $this->container->setDefinition('Sylius\Bundle\CoreBundle\EventListener\Workflow\Order\CancelPaymentListener', $listenerDefinition);
+        $this->container->setDefinition(self::CANCEL_PAYMENT_LISTENER_SERVICE_ID, $listenerDefinition);
 
         $this->compilerPass->process($this->container);
 
-        $this->assertTrue($this->container->hasDefinition('Sylius\Bundle\CoreBundle\EventListener\Workflow\Order\CancelPaymentListener'));
+        $this->assertTrue($this->container->hasDefinition(self::CANCEL_PAYMENT_LISTENER_SERVICE_ID));
     }
 
     public function testItDoesNothingWhenCancelPaymentListenerDoesNotExist(): void
@@ -47,7 +49,7 @@ final class RemoveCancelPaymentListenerPassTest extends TestCase
 
         $this->compilerPass->process($this->container);
 
-        $this->assertFalse($this->container->hasDefinition('Sylius\Bundle\CoreBundle\EventListener\Workflow\Order\CancelPaymentListener'));
+        $this->assertFalse($this->container->hasDefinition(self::CANCEL_PAYMENT_LISTENER_SERVICE_ID));
     }
 
     public function testItRemovesListenerWhenBothDefinitionsExist(): void
@@ -56,12 +58,12 @@ final class RemoveCancelPaymentListenerPassTest extends TestCase
         $this->container->setDefinition('state_machine.sylius_order.definition', $orderDefinition);
 
         $listenerDefinition = new Definition();
-        $this->container->setDefinition('Sylius\Bundle\CoreBundle\EventListener\Workflow\Order\CancelPaymentListener', $listenerDefinition);
+        $this->container->setDefinition(self::CANCEL_PAYMENT_LISTENER_SERVICE_ID, $listenerDefinition);
 
-        $this->assertTrue($this->container->hasDefinition('Sylius\Bundle\CoreBundle\EventListener\Workflow\Order\CancelPaymentListener'));
+        $this->assertTrue($this->container->hasDefinition(self::CANCEL_PAYMENT_LISTENER_SERVICE_ID));
 
         $this->compilerPass->process($this->container);
 
-        $this->assertFalse($this->container->hasDefinition('Sylius\Bundle\CoreBundle\EventListener\Workflow\Order\CancelPaymentListener'));
+        $this->assertFalse($this->container->hasDefinition(self::CANCEL_PAYMENT_LISTENER_SERVICE_ID));
     }
 }


### PR DESCRIPTION
Added a test on triggering reversal through cancellation of the order in automatic mode