### PR TITLE
Add telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ For online communication, we invite you to chat with us and other users on [Syli
 ## License
 
 This plugin is released under the [MIT License](LICENSE).
+
+## Telemetry
+
+This plugin enforces telemetry data collection when used with Sylius.
+Details are described in [TELEMETRY_POLICY.md](./TELEMETRY_POLICY.md).

--- a/TELEMETRY_POLICY.md
+++ b/TELEMETRY_POLICY.md
@@ -1,0 +1,69 @@
+# Telemetry Policy
+
+## Applicability
+
+This Telemetry Policy applies to the use of this plugin in combination with Sylius.
+
+By installing or using this plugin with Sylius, the user acknowledges that telemetry data is collected and transmitted as described in this document.
+
+---
+
+## Mandatory telemetry
+
+Telemetry data collection is mandatory when this plugin is used.
+
+While this plugin is installed and active, Sylius telemetry operates under the conditions defined by this plugin and cannot be disabled independently.
+Telemetry behavior outside of this scope follows the standard Sylius configuration.
+
+---
+
+## Scope of collected data
+
+Telemetry is limited to non-identifying technical data, which may include:
+
+- Sylius version
+- plugin version
+- PHP version and selected dependency versions
+- identifiers of installed and enabled plugins
+- runtime environment classification (production or non-production)
+
+Telemetry does not include, and is not intended to include:
+
+- personal data
+- customer data
+- order data
+- product data
+- business, transactional, or confidential information
+- authentication credentials or secrets
+
+A detailed description of the Sylius telemetry mechanism is available in the public issue:
+https://github.com/Sylius/Sylius/issues/18588
+
+---
+
+## Purpose and use of telemetry data
+
+Telemetry data is collected for the purpose of:
+
+- understanding usage patterns within the Sylius ecosystem
+- analyzing the adoption and frequency of plugin usage
+- identifying commonly used versions of Sylius and plugins
+- supporting maintenance, compatibility, and future development efforts
+
+Telemetry data is processed in aggregated form and is not used to identify individual users, installations, or businesses.
+
+---
+
+## Licensing
+
+This plugin is distributed under the MIT license.
+
+Telemetry collection constitutes part of the technical operation of the software and does not alter, restrict, or supplement the rights granted under the license.
+
+---
+
+## Changes to this policy
+
+This Telemetry Policy may be updated to reflect changes in telemetry implementation, legal requirements, or operational practices.
+
+Updated versions of this policy will be made available in the plugin repository.

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "composer/package-versions-deprecated": "^1.11",
         "sylius/refund-plugin": "^2.0",
         "sylius/sylius": "^2.0",
+        "sylius/telemetry": "^1.0",
         "symfony/messenger": "^6.4 || ^7.2",
         "symfony/serializer": "^6.4 || ^7.2",
         "symfony/webpack-encore-bundle": "^2.2"
@@ -82,7 +83,10 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Sylius\\AdyenPlugin\\": ["tests/", "tests/TestApplication/src/"]
+            "Tests\\Sylius\\AdyenPlugin\\": [
+                "tests/",
+                "tests/TestApplication/src/"
+            ]
         }
     }
 }

--- a/src/SyliusAdyenPlugin.php
+++ b/src/SyliusAdyenPlugin.php
@@ -17,6 +17,7 @@ use Sylius\AdyenPlugin\DependencyInjection\Compiler\AddOrderPaymentWorkflowTrans
 use Sylius\AdyenPlugin\DependencyInjection\Compiler\AddPaymentWorkflowTransitionPass;
 use Sylius\AdyenPlugin\DependencyInjection\Compiler\RemoveCancelPaymentListenerPass;
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
+use Sylius\Telemetry\TelemetryCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -31,6 +32,7 @@ final class SyliusAdyenPlugin extends Bundle
         $container->addCompilerPass(new AddOrderPaymentWorkflowTransitionPass());
         $container->addCompilerPass(new AddPaymentWorkflowTransitionPass());
         $container->addCompilerPass(new RemoveCancelPaymentListenerPass());
+        $container->addCompilerPass(new TelemetryCompilerPass());
     }
 
     public function getPath(): string


### PR DESCRIPTION
Adds telemetry policy and `sylius/telemetry-bundle` as a hard dependency.

- `TELEMETRY_POLICY.md` — describes scope, purpose, and conditions of telemetry data collection
- `composer.json` — requires `sylius/telemetry-bundle: ^1.0`
- `README.md` — telemetry notice pointing to the policy file

Related: https://github.com/Sylius/Sylius/issues/18588