### PR TITLE
[Maintenance] Replaced Gedmo extension with Doctrine's built-in lifecycle callbacks for `createdAt` and `updatedAt` fields

### DIFF
--- a/config/doctrine/AdyenPaymentDetail.orm.xml
+++ b/config/doctrine/AdyenPaymentDetail.orm.xml
@@ -3,10 +3,14 @@
 <doctrine-mapping
     xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
     xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
     <mapped-superclass name="Sylius\AdyenPlugin\Entity\AdyenPaymentDetail" table="sylius_adyen_payment_detail">
+        <lifecycle-callbacks>
+            <lifecycle-callback type="prePersist" method="setCreatedAtValue"/>
+            <lifecycle-callback type="preUpdate" method="setUpdatedAtValue"/>
+        </lifecycle-callbacks>
+
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO"/>
         </id>
@@ -19,12 +23,8 @@
             </options>
         </field>
 
-        <field name="createdAt" column="created_at" type="datetime">
-            <gedmo:timestampable on="create"/>
-        </field>
-        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
-            <gedmo:timestampable on="update"/>
-        </field>
+        <field name="createdAt" column="created_at" type="datetime"/>
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true"/>
 
         <one-to-one field="payment" target-entity="Sylius\Component\Payment\Model\PaymentInterface">
             <join-column name="payment_id" on-delete="CASCADE"/>

--- a/config/doctrine/AdyenReference.orm.xml
+++ b/config/doctrine/AdyenReference.orm.xml
@@ -3,22 +3,22 @@
 <doctrine-mapping
     xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
     xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
     <mapped-superclass name="Sylius\AdyenPlugin\Entity\AdyenReference" table="sylius_adyen_reference">
+        <lifecycle-callbacks>
+            <lifecycle-callback type="prePersist" method="setCreatedAtValue"/>
+            <lifecycle-callback type="preUpdate" method="setUpdatedAtValue"/>
+        </lifecycle-callbacks>
+
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO"/>
         </id>
 
         <field name="pspReference" type="string" column="psp_reference" length="64" unique="true" />
 
-        <field name="createdAt" column="created_at" type="datetime">
-            <gedmo:timestampable on="create"/>
-        </field>
-        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
-            <gedmo:timestampable on="update"/>
-        </field>
+        <field name="createdAt" column="created_at" type="datetime"/>
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true"/>
 
         <many-to-one field="payment" target-entity="Sylius\Component\Payment\Model\PaymentInterface">
             <join-column name="payment_id" on-delete="CASCADE"/>

--- a/src/Entity/AdyenPaymentDetail.php
+++ b/src/Entity/AdyenPaymentDetail.php
@@ -31,6 +31,16 @@ class AdyenPaymentDetail implements ResourceInterface, TimestampableInterface, A
 
     protected PaymentInterface $payment;
 
+    public function setCreatedAtValue(): void
+    {
+        $this->setCreatedAt(new \DateTime());
+    }
+
+    public function setUpdatedAtValue(): void
+    {
+        $this->setUpdatedAt(new \DateTime());
+    }
+
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Entity/AdyenReference.php
+++ b/src/Entity/AdyenReference.php
@@ -31,6 +31,16 @@ class AdyenReference implements ResourceInterface, AdyenReferenceInterface, Time
 
     protected ?RefundPaymentInterface $refundPayment;
 
+    public function setCreatedAtValue(): void
+    {
+        $this->setCreatedAt(new \DateTime());
+    }
+
+    public function setUpdatedAtValue(): void
+    {
+        $this->setUpdatedAt(new \DateTime());
+    }
+
     public function getId(): ?int
     {
         return $this->id;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #170
| License         | MIT

This PR makes the plugin more flexible and consistent for flat Symfony/DoctrineORM applications.