### PR TITLE
Fix workflow transition guard skipping already-registered transitions

### DIFF
--- a/src/DependencyInjection/Compiler/AbstractWorkflowTransitionPass.php
+++ b/src/DependencyInjection/Compiler/AbstractWorkflowTransitionPass.php
@@ -16,6 +16,7 @@ namespace Sylius\AdyenPlugin\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Workflow\Transition;
 
 abstract class AbstractWorkflowTransitionPass implements CompilerPassInterface
@@ -30,7 +31,7 @@ abstract class AbstractWorkflowTransitionPass implements CompilerPassInterface
         $definition = $container->getDefinition($definitionId);
         $transitions = $definition->getArgument(1);
 
-        $existingTransitions = $this->extractExistingTransitions($transitions);
+        $existingTransitions = $this->extractExistingTransitions($container, $transitions);
         $updatedTransitions = $this->addMissingTransitions($transitions, $existingTransitions);
 
         $definition->setArgument(1, $updatedTransitions);
@@ -42,16 +43,17 @@ abstract class AbstractWorkflowTransitionPass implements CompilerPassInterface
     abstract protected function getRequiredTransitions(): array;
 
     /**
-     * @param array<Definition> $transitions
+     * @param array<Definition|Reference> $transitions
      *
      * @return array<string>
      */
-    private function extractExistingTransitions(array $transitions): array
+    private function extractExistingTransitions(ContainerBuilder $container, array $transitions): array
     {
         $existingTransitions = [];
 
         foreach ($transitions as $transition) {
-            if (!$transition instanceof Definition) {
+            $transition = $this->resolveTransitionDefinition($container, $transition);
+            if (null === $transition) {
                 continue;
             }
 
@@ -61,8 +63,18 @@ abstract class AbstractWorkflowTransitionPass implements CompilerPassInterface
             }
 
             [$name, $froms, $tos] = $arguments;
-            foreach ($froms as $from) {
-                foreach ($tos as $to) {
+            foreach ((array) $froms as $from) {
+                $from = $this->resolvePlaceName($from);
+                if (null === $from) {
+                    continue;
+                }
+
+                foreach ((array) $tos as $to) {
+                    $to = $this->resolvePlaceName($to);
+                    if (null === $to) {
+                        continue;
+                    }
+
                     $existingTransitions[] = $this->createTransitionKey($name, $from, $to);
                 }
             }
@@ -71,11 +83,38 @@ abstract class AbstractWorkflowTransitionPass implements CompilerPassInterface
         return $existingTransitions;
     }
 
+    private function resolveTransitionDefinition(ContainerBuilder $container, mixed $transition): ?Definition
+    {
+        if ($transition instanceof Reference) {
+            $transitionId = (string) $transition;
+            if (!$container->hasDefinition($transitionId)) {
+                return null;
+            }
+
+            $transition = $container->getDefinition($transitionId);
+        }
+
+        return $transition instanceof Definition ? $transition : null;
+    }
+
+    private function resolvePlaceName(mixed $place): ?string
+    {
+        if (is_string($place)) {
+            return $place;
+        }
+
+        if ($place instanceof Definition) {
+            return (string) $place->getArgument(0);
+        }
+
+        return null;
+    }
+
     /**
-     * @param array<Definition> $transitions
+     * @param array<Definition|Reference> $transitions
      * @param array<string> $existingTransitions
      *
-     * @return array<Definition>
+     * @return array<Definition|Reference>
      */
     private function addMissingTransitions(array $transitions, array $existingTransitions): array
     {

--- a/tests/Unit/DependencyInjection/Compiler/AddOrderPaymentWorkflowTransitionPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/AddOrderPaymentWorkflowTransitionPassTest.php
@@ -88,7 +88,7 @@ final class AddOrderPaymentWorkflowTransitionPassTest extends TestCase
         $this->assertSame(2, $requestPaymentTransitionsCount);
     }
 
-    public function testItAddsRequiredTransitionsWhenExistingTransitionIsAnUnresolvedReference(): void
+    public function testItDoesNotAddDuplicateTransitionsWhenReferenceResolvesToExistingDefinition(): void
     {
         $existingTransition = new Definition(Transition::class);
         $existingTransition->setArguments(['request_payment', ['paid'], ['awaiting_payment']]);
@@ -104,7 +104,7 @@ final class AddOrderPaymentWorkflowTransitionPassTest extends TestCase
         $transitions = $definition->getArgument(1);
 
         $extra = self::isAuthorizedTransitionRequired() ? 1 : 0;
-        $this->assertCount(3 + $extra, $transitions);
+        $this->assertCount(2 + $extra, $transitions);
 
         $requestPaymentTransitionsCount = 0;
         foreach ($transitions as $transition) {
@@ -113,10 +113,10 @@ final class AddOrderPaymentWorkflowTransitionPassTest extends TestCase
             }
         }
 
-        $this->assertSame(1 + $extra, $requestPaymentTransitionsCount);
+        $this->assertSame($extra, $requestPaymentTransitionsCount);
     }
 
-    public function testItAddsRequiredTransitionsWhenExistingTransitionUsesScalarFromAndTo(): void
+    public function testItDoesNotAddDuplicateTransitionsWhenExistingTransitionUsesScalarFromAndTo(): void
     {
         $existingTransition = new Definition(Transition::class);
         $existingTransition->setArguments(['request_payment', 'paid', 'awaiting_payment']);
@@ -131,7 +131,7 @@ final class AddOrderPaymentWorkflowTransitionPassTest extends TestCase
         $transitions = $definition->getArgument(1);
 
         $extra = self::isAuthorizedTransitionRequired() ? 1 : 0;
-        $this->assertCount(3 + $extra, $transitions);
+        $this->assertCount(2 + $extra, $transitions);
 
         $requestPaymentTransitionsCount = 0;
         foreach ($transitions as $transition) {
@@ -140,7 +140,38 @@ final class AddOrderPaymentWorkflowTransitionPassTest extends TestCase
             }
         }
 
-        $this->assertSame(2 + $extra, $requestPaymentTransitionsCount);
+        $this->assertSame(1 + $extra, $requestPaymentTransitionsCount);
+    }
+
+    public function testItDoesNotAddDuplicateTransitionsWhenExistingTransitionUsesWeightedArcPlaces(): void
+    {
+        $existingTransition = new Definition(Transition::class);
+        $existingTransition->setArguments([
+            'request_payment',
+            [new Definition('Symfony\\Component\\Workflow\\Arc', ['paid', 1])],
+            [new Definition('Symfony\\Component\\Workflow\\Arc', ['awaiting_payment', 1])],
+        ]);
+
+        $workflowDefinition = new Definition();
+        $workflowDefinition->setArguments(['places', [$existingTransition]]);
+        $this->container->setDefinition('state_machine.sylius_order_payment.definition', $workflowDefinition);
+
+        $this->compilerPass->process($this->container);
+
+        $definition = $this->container->getDefinition('state_machine.sylius_order_payment.definition');
+        $transitions = $definition->getArgument(1);
+
+        $extra = self::isAuthorizedTransitionRequired() ? 1 : 0;
+        $this->assertCount(2 + $extra, $transitions);
+
+        $requestPaymentTransitionsCount = 0;
+        foreach ($transitions as $transition) {
+            if ($transition instanceof Definition && $transition->getArgument(0) === 'request_payment') {
+                ++$requestPaymentTransitionsCount;
+            }
+        }
+
+        $this->assertSame(1 + $extra, $requestPaymentTransitionsCount);
     }
 
     public function testItIgnoresReferenceToNonExistentDefinition(): void


### PR DESCRIPTION
## Summary                                                                                                                                                                                              
                                                                                                                                                                                                          
  - Fixes a bug where `AbstractWorkflowTransitionPass` fails to detect transitions already registered on a `state_machine` workflow, causing it to add duplicate transitions unconditionally.             
  - Fixes the specific case in `AddOrderPaymentWorkflowTransitionPass`, where a duplicate `request_payment: authorized → awaiting_payment` transition causes an unhandled `InvalidArgumentException` on   
  Sylius versions where Core already defines that transition natively (2.2.7+).                                                                                                                           
                                                                                                                                                                                                          
  ## Root cause                                                                                                                                                                                           
                                                                                                                                                                                                          
  The existing-transition check only recognized inline `Definition` instances:                                                                                                                            
                                                                                                                                                                                                          
  ```php                                                                                                                                                                                                  
  foreach ($transitions as $transition) {                                                                                                                                                                 
      if (!$transition instanceof Definition) {                                                                                                                                                           
          continue;                                                                                                                                                                                       
      }                                                                                                                                                                                                   
      ...                                                                                                                                                                                                 
  }
```

For state_machine-type workflows, Symfony's FrameworkExtension registers each transition as its own container service and puts a Reference to it in the transitions array — never an inline Definition. 
  Since a Reference is never instanceof Definition, the scan always found zero existing transitions, so the pass always added its required transitions, even ones already present.                        
                                                                                                                                                                                                          
  Two Transition definitions with the same name/from/to are not a harmless duplicate: Workflow::apply() approves both matches on a single transition call. The first leave() unmarks authorized; the second leave() then calls Marking::unmark('authorized') again on a place that's no longer marked, throwing: InvalidArgumentException: The place "authorized" is not marked.                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                          
## Fix                                                                                                                                                                                                   
                                                                                                                                                                                                          
  - Resolve Reference entries to their underlying Definition (via ContainerBuilder::getDefinition()) before inspecting a transition's arguments, so transitions registered as standalone services are correctly detected as "existing."                                                                                                                                                                       
  - Generalize how a from/to place is read: Symfony represents a weighted place as Definition(Arc::class, [$place, $weight]) instead of a plain string. Any Definition found in that position is now read via its first constructor argument — no class-name check needed, since that's the only shape Symfony ever produces there. This removes any dependency on the Arc class, which doesn't exist in older Symfony/Workflow releases and previously broke static analysis on that version matrix.    